### PR TITLE
fix: resolve TypeScript build dependency issue in Amplify

### DIFF
--- a/code/amplify.yml
+++ b/code/amplify.yml
@@ -7,6 +7,7 @@ applications:
           commands:
             - echo "Installing dependencies..."
             - npm ci
+            - npm install typescript --save-dev
             - echo "Dependencies installed successfully"
         build:
           commands:


### PR DESCRIPTION
## 🐛 문제
- Amplify 빌드 시 TypeScript 모듈을 찾을 수 없는 오류 발생
- `Cannot find module 'typescript'` 에러로 빌드 실패

## 🔧 해결방법
- preBuild 단계에서 TypeScript를 명시적으로 설치
- `npm install typescript --save-dev` 명령어 추가

## ✅ 테스트
- [ ] Amplify 빌드 성공 확인
- [ ] Next.js 애플리케이션 정상 배포 확인

## 📋 변경사항
- `code/amplify.yml`: preBuild 단계에 TypeScript 설치 명령어 추가