### PR TITLE
fix: change npm ci to npm install for TypeScript compatibility

### DIFF
--- a/code/amplify.yml
+++ b/code/amplify.yml
@@ -6,8 +6,7 @@ applications:
         preBuild:
           commands:
             - echo "Installing dependencies..."
-            - npm ci
-            - npm install typescript --save-dev
+            - npm install
             - echo "Dependencies installed successfully"
         build:
           commands:


### PR DESCRIPTION
## 🐛 문제
- `next.config.ts` 로딩 시 TypeScript 모듈을 찾을 수 없는 오류
- `npm ci` 후 TypeScript 설치해도 Next.js가 인식하지 못함

## 🔧 해결방법
- `npm ci` → `npm install`로 변경
- TypeScript가 포함된 전체 의존성을 한 번에 설치
- `next.config.ts` 파일을 TypeScript로 유지

## ✅ 장점
- TypeScript 설정 유지
- 의존성 설치 단순화
- Next.js 빌드 호환성 개선

## 📋 변경사항
- `code/amplify.yml`: npm ci → npm install 변경
- 별도 TypeScript 설치 명령어 제거