### PR TITLE
fix: resolve TypeScript compilation errors in documents API

### DIFF
--- a/backend/src/functions/documents/index.ts
+++ b/backend/src/functions/documents/index.ts
@@ -223,7 +223,7 @@ async function updateDocument(documentId: string, body: UpdateDocumentRequest, u
   // Check document ownership
   const ownershipCheck = await verifyDocumentOwnership(documentId, userId);
   if (!ownershipCheck.success) {
-    return ownershipCheck.response;
+    return ownershipCheck.response!;
   }
 
   if (!title && !content) {
@@ -310,7 +310,7 @@ async function patchDocument(documentId: string, body: PatchDocumentRequest, use
   // Check document ownership
   const ownershipCheck = await verifyDocumentOwnership(documentId, userId);
   if (!ownershipCheck.success) {
-    return ownershipCheck.response;
+    return ownershipCheck.response!;
   }
 
   // Get current document for version check
@@ -391,7 +391,7 @@ async function deleteDocument(documentId: string, userId: string): Promise<APIGa
   // Check document ownership
   const ownershipCheck = await verifyDocumentOwnership(documentId, userId);
   if (!ownershipCheck.success) {
-    return ownershipCheck.response;
+    return ownershipCheck.response!;
   }
 
   await docClient.send(new DeleteCommand({
@@ -409,7 +409,11 @@ async function deleteDocument(documentId: string, userId: string): Promise<APIGa
   };
 }
 
-async function verifyDocumentOwnership(documentId: string, userId: string) {
+async function verifyDocumentOwnership(documentId: string, userId: string): Promise<{
+  success: boolean;
+  response?: APIGatewayProxyResult;
+  document?: any;
+}> {
   const document = await docClient.send(new GetCommand({
     TableName: process.env.DOCUMENTS_TABLE_NAME,
     Key: { documentId },

--- a/docs/log/2024-12-19-backend-build-fix.md
+++ b/docs/log/2024-12-19-backend-build-fix.md
@@ -1,0 +1,41 @@
+# Backend Build Fix - 2024-12-19
+
+## Task Summary
+Fixed TypeScript compilation errors in backend documents API and successfully built the project.
+
+## Changes Made
+
+### Files Modified
+- `backend/src/functions/documents/index.ts`
+
+### Issues Fixed
+1. **TypeScript Return Type Error**: Fixed `verifyDocumentOwnership` function return type
+   - Added explicit return type annotation with optional `response` property
+   - Used non-null assertion operator (`!`) for guaranteed response access
+   - Resolved 3 compilation errors at lines 226, 313, and 394
+
+### Technical Details
+```typescript
+// Before: Implicit return type causing undefined possibility
+async function verifyDocumentOwnership(documentId: string, userId: string) {
+
+// After: Explicit return type with proper typing
+async function verifyDocumentOwnership(documentId: string, userId: string): Promise<{
+  success: boolean;
+  response?: APIGatewayProxyResult;
+  document?: any;
+}> {
+```
+
+## Build Status
+- ✅ TypeScript compilation successful
+- ✅ No build errors
+- ✅ Ready for deployment
+
+## Next Steps
+- Deploy CDK stack to AWS
+- Test API endpoints in production environment
+- Complete end-to-end integration testing
+
+## Files Affected
+- `backend/src/functions/documents/index.ts` - Fixed return type annotations


### PR DESCRIPTION
- Fixed verifyDocumentOwnership function return type annotations
- Added explicit Promise return type with optional response property
- Used non-null assertion operator for guaranteed response access
- Resolved 3 compilation errors at lines 226, 313, and 394
- Backend build now successful with no TypeScript errors

Files changed:
- backend/src/functions/documents/index.ts
- docs/log/2024-12-19-backend-build-fix.md