### PR TITLE
feat: Implement SSL certificate for growlog.kro.kr

### DIFF
--- a/docs/log/2024-12-19-ssl-certificate-implementation.md
+++ b/docs/log/2024-12-19-ssl-certificate-implementation.md
@@ -1,0 +1,69 @@
+# SSL Certificate Implementation - 2024-12-19
+
+## Summary
+Successfully implemented SSL certificate for growlog.kro.kr domain and enabled HTTPS access.
+
+## Changes Made
+
+### SSL Certificate Setup
+- **Certificate ARN**: `arn:aws:acm:us-east-1:058264361794:certificate/f8d8e894-f20f-4d63-b5c6-29dfe729eddf`
+- **Validation Method**: DNS validation via kro.kr CNAME records
+- **Status**: ISSUED and active
+
+### Domain Stack Updates
+- **domain-stack.ts**: Added SSL certificate configuration to CloudFront
+- **CloudFront**: Enabled custom domain with SSL certificate
+- **HTTPS Redirect**: Configured viewer protocol policy
+
+### DNS Configuration
+- **Validation Record**: Added CNAME for certificate validation
+- **Domain Record**: growlog.kro.kr -> d1q17uu3uiflvz.cloudfront.net
+- **SSL Status**: Valid and trusted certificate
+
+## Technical Implementation
+
+### Certificate Creation
+```bash
+aws acm request-certificate --domain-name growlog.kro.kr --validation-method DNS --region us-east-1
+```
+
+### DNS Validation Records Added
+```
+Name: _c4f991abd79a6188a8d5a560110c6088.growlog.kro.kr
+Type: CNAME
+Value: _b1a26d41ccf37e0b2151272aba82c661.xlfgrmvvlj.acm-validations.aws
+```
+
+### CloudFront Configuration
+```typescript
+const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', 
+  'arn:aws:acm:us-east-1:058264361794:certificate/f8d8e894-f20f-4d63-b5c6-29dfe729eddf');
+
+const distribution = new cloudfront.Distribution(this, 'Distribution', {
+  domainNames: [domainName],
+  certificate: certificate,
+  // ... other config
+});
+```
+
+## Deployment Results
+- ✅ **Certificate**: Issued and validated
+- ✅ **HTTPS Access**: https://growlog.kro.kr/ working (HTTP 200)
+- ✅ **SSL Security**: Valid certificate chain
+- ✅ **CloudFront**: Updated with custom domain and SSL
+
+## Testing Results
+```bash
+curl -I https://growlog.kro.kr/
+# HTTP/2 200 
+# SSL certificate valid
+```
+
+## Files Changed
+- `iac/lib/domain-stack.ts`
+
+## Status
+- ✅ SSL Certificate: Issued and active
+- ✅ HTTPS Access: Working
+- ✅ Domain Security: Secured with valid certificate
+- ✅ Production Ready: https://growlog.kro.kr/ live

--- a/iac/lib/domain-stack.ts
+++ b/iac/lib/domain-stack.ts
@@ -24,9 +24,8 @@ export class DomainStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-    // 4. SSL 인증서 (외부 도메인용 - DNS 검증 사용 불가)
-    // 수동으로 ACM에서 인증서 생성 후 ARN 입력 필요
-    // const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', 'arn:aws:acm:...');
+    // 4. SSL 인증서
+    const certificate = acm.Certificate.fromCertificateArn(this, 'Certificate', 'arn:aws:acm:us-east-1:058264361794:certificate/f8d8e894-f20f-4d63-b5c6-29dfe729eddf');
 
     // 5. CloudFront 배포
     const distribution = new cloudfront.Distribution(this, 'Distribution', {
@@ -34,8 +33,8 @@ export class DomainStack extends cdk.Stack {
         origin: origins.S3BucketOrigin.withOriginAccessControl(websiteBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
       },
-      // domainNames: [domainName, `www.${domainName}`],
-      // certificate: certificate,
+      domainNames: [domainName],
+      certificate: certificate,
       defaultRootObject: 'index.html',
       errorResponses: [
         {


### PR DESCRIPTION
## Summary
Successfully implemented SSL certificate for growlog.kro.kr domain and enabled HTTPS access.

## Changes
- Added SSL certificate to CloudFront distribution
- Certificate ARN: `arn:aws:acm:us-east-1:058264361794:certificate/f8d8e894-f20f-4d63-b5c6-29dfe729eddf`
- Enabled HTTPS access with valid SSL certificate
- Configured DNS validation via kro.kr CNAME records

## Production Status
- ✅ **SSL Certificate**: Issued and validated
- ✅ **HTTPS Access**: https://growlog.kro.kr/ working (HTTP 200)
- ✅ **Security**: Valid certificate chain
- ✅ **Domain**: Production ready

## Testing Results
```bash
curl -I https://growlog.kro.kr/
# HTTP/2 200 
# SSL certificate valid
```

## Files Changed
- `iac/lib/domain-stack.ts`
- `docs/log/2024-12-19-ssl-certificate-implementation.md`