### PR TITLE
fix: redirect to landing page on logout

### DIFF
--- a/code/src/components/layout/ProtectedRoute.tsx
+++ b/code/src/components/layout/ProtectedRoute.tsx
@@ -14,7 +14,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   useEffect(() => {
     if (!isLoading && !user) {
-      router.push('/login');
+      router.push('/');
     }
   }, [user, isLoading, router]);
 

--- a/code/src/lib/auth-context.tsx
+++ b/code/src/lib/auth-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
 import { User } from '@/types';
 import { apiClient, setToastCallback } from './api';
 import { useToast } from '@/components/ui/toast';
@@ -21,6 +22,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { showToast } = useToast();
+  const router = useRouter();
 
   useEffect(() => {
     setToastCallback(showToast);
@@ -78,6 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('user_data');
     setUser(null);
     setError(null);
+    router.push('/');
   };
 
   return (


### PR DESCRIPTION
- Modified logout function in auth-context to redirect to '/' instead of staying on current page
- Updated ProtectedRoute to redirect unauthenticated users to landing page instead of login page
- Ensures consistent user experience when logging out from any page