### PR TITLE
feat: add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to S3
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+        cache-dependency-path: code/package-lock.json
+    
+    - name: Install dependencies
+      run: |
+        cd code
+        npm ci
+    
+    - name: Build
+      run: |
+        cd code
+        npm run build
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    
+    - name: Deploy to S3
+      run: |
+        cd code
+        aws s3 sync out/ s3://team35-hackathon-frontend --delete
+    
+    - name: Invalidate CloudFront
+      if: github.ref == 'refs/heads/main'
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## 추가 기능
- GitHub Actions 자동 배포 파이프라인
- main/develop 브랜치 푸시 시 자동 빌드 & S3 배포
- main 브랜치 배포 시 CloudFront 캐시 무효화

## 설정 필요
GitHub Secrets 추가:
- AWS_ACCESS_KEY_ID: AKIAQ3EGTTNBGCQTOU4V
- AWS_SECRET_ACCESS_KEY: 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

## 테스트
- 빌드 성공 확인
- 배포 자동화 구현