### PR TITLE
fix: improve CloudFront SPA routing with proper page access control

### DIFF
--- a/code/src/app/page.tsx
+++ b/code/src/app/page.tsx
@@ -16,10 +16,15 @@ function HomeContent() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    // S3에서 리다이렉트된 경우 처리
+    // CloudFront에서 리다이렉트된 경우 처리
     const redirect = searchParams.get('redirect');
+    const currentPath = window.location.pathname;
+    
     if (redirect && user) {
       router.replace(redirect);
+    } else if (currentPath !== '/' && user) {
+      // CloudFront가 404를 index.html로 리다이렉트한 경우
+      router.replace(currentPath);
     }
   }, [searchParams, user, router]);
 

--- a/code/src/app/page.tsx
+++ b/code/src/app/page.tsx
@@ -22,9 +22,18 @@ function HomeContent() {
     
     if (redirect && user) {
       router.replace(redirect);
-    } else if (currentPath !== '/' && user) {
+    } else if (currentPath !== '/') {
       // CloudFront가 404를 index.html로 리다이렉트한 경우
-      router.replace(currentPath);
+      const authPages = ['/login/', '/register/'];
+      const protectedPages = ['/dashboard/', '/documents/', '/analysis/', '/daily/', '/tests/', '/resume/'];
+      
+      if (authPages.includes(currentPath) && !user) {
+        // 로그인 안 된 사용자만 로그인/회원가입 페이지 접근 가능
+        router.replace(currentPath);
+      } else if (protectedPages.includes(currentPath) && user) {
+        // 로그인된 사용자만 보호된 페이지 접근 가능
+        router.replace(currentPath);
+      }
     }
   }, [searchParams, user, router]);
 


### PR DESCRIPTION
## 문제
CloudFront에서 404 → index.html 리다이렉트 시 올바른 페이지 접근 제어가 없었음

## 해결
- 로그인 안 된 사용자: /login/, /register/ 페이지만 접근 가능
- 로그인된 사용자: /dashboard/, /documents/ 등 보호된 페이지 접근 가능
- 잘못된 접근 시 홈페이지에서 적절한 액션 유도

## 테스트
- 로그인 후 /dashboard/ 직접 접근 → 대시보드 표시
- 로그아웃 후 /login/ 직접 접근 → 로그인 페이지 표시
- 로그인 후 /login/ 접근 → 홈페이지에서 대시보드 버튼 표시