### PR TITLE
Fix: Update deployment to main branch configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to S3
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -40,7 +40,7 @@ jobs:
     - name: Deploy to S3
       run: |
         cd code
-        aws s3 sync out/ s3://team35-hackathon-frontend --delete
+        aws s3 sync out/ s3://growlog-kro-kr-website --delete
     
     - name: Invalidate CloudFront
       if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Changes
- Change GitHub Actions deployment trigger from develop to main branch only
- Update S3 bucket from team35-hackathon-frontend to growlog-kro-kr-website  
- Simplify CloudFront invalidation to main branch only

## Why
- Merged develop into main, now need to deploy from main branch
- Correct S3 bucket is growlog-kro-kr-website (matches CloudFront origin)
- Clean up deployment workflow for production

## Testing
- [ ] Verify GitHub Actions runs on main branch push
- [ ] Confirm S3 sync to correct bucket
- [ ] Check CloudFront invalidation works

Ready to merge and deploy from main branch.